### PR TITLE
Enable build with ETCD_UNSUPPORTED_ARCH for s390x

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -64,6 +64,8 @@ steps:
   pull: always
   image: rancher/hardened-build-base:v1.16.9b7
   failure: ignore
+  environment:
+    ETCD_UNSUPPORTED_ARCH: s390x
   commands:
   - make DRONE_TAG=${DRONE_TAG}
   volumes:

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN go mod vendor \
     fi
 
 RUN go-assert-static.sh bin/*
+ARG ETCD_UNSUPPORTED_ARCH
+ENV ETCD_UNSUPPORTED_ARCH=$ETCD_UNSUPPORTED_ARCH
 RUN if [ "${ARCH}" != "s390x" ]; then \
 	go-assert-boring.sh bin/*; \
     fi

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ image-build:
 		--build-arg SRC=$(SRC) \
 		--build-arg TAG=$(TAG:$(BUILD_META)=) \
 		--build-arg ARCH=$(ARCH) \
+		--build-arg ETCD_UNSUPPORTED_ARCH=$(ETCD_UNSUPPORTED_ARCH) \
 		--tag $(ORG)/hardened-etcd:$(TAG) \
 		--tag $(ORG)/hardened-etcd:$(TAG)-$(ARCH) \
 	.


### PR DESCRIPTION
We need to set `ETCD_UNSUPPORTED_ARCH` env variable to `s390x` in order to avoid failing on the building step for `etcd v3.4.13`