### PR TITLE
add ETCD_UNSUPPORTED_ARCH to ubi container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,6 @@ RUN etcd --version
 FROM ubi
 RUN microdnf update -y && \ 
     rm -rf /var/cache/yum
+ARG ETCD_UNSUPPORTED_ARCH
+ENV ETCD_UNSUPPORTED_ARCH=$ETCD_UNSUPPORTED_ARCH
 COPY --from=builder /usr/local/bin/ /usr/local/bin/


### PR DESCRIPTION
we need ETCD_UNSUPPORTED_ARCH for s390x 