### PR TITLE
CI will ignore push to non-master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,6 +16,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/pull/**
+      - refs/tags/*
 
 - name: publish
   image: rancher/hardened-build-base:v1.20.4b11
@@ -41,6 +47,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/pull/**
+      - refs/tags/*
 
 volumes:
 - name: docker
@@ -65,6 +77,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/pull/**
+      - refs/tags/*
 
 - name: publish
   image: rancher/hardened-build-base:v1.20.4b11
@@ -90,6 +108,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/pull/**
+      - refs/tags/*
 
 volumes:
 - name: docker
@@ -120,6 +144,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/pull/**
+      - refs/tags/*
 
 - name: publish
   image: rancher/hardened-build-base:v1.20.4b11


### PR DESCRIPTION
This contributes to rancher/rke2#4248

We want CI to exclude push events from dev or automated branches