### PR TITLE
publish-image-action

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -23,14 +23,22 @@ jobs:
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
-          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD
+          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD
 
     - name: Build and push image
       uses: rancher/ecm-distro-tools/actions/publish-image@master
       with:
         image: hardened-etcd
         tag: ${{ github.event.release.tag_name }}
+
         public-repo: rancher
         public-username: ${{ env.DOCKER_USERNAME }}
         public-password: ${{ env.DOCKER_PASSWORD }}
-        push-to-prime: false
+
+        prime-repo: rancher
+        prime-registry: ${{ env.PRIME_REGISTRY }}
+        prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+        prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -18,14 +18,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Set the TAG value
-      id: get-TAG
-      run: |
-        echo "$(make -s log | grep TAG)" >> "$GITHUB_ENV"
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
     - name: "Read secrets"
       uses: rancher-eio/read-vault-secrets@main
       with:
@@ -33,22 +25,12 @@ jobs:
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Login to Container Registry
-      uses: docker/login-action@v3
+    - name: Build and push image
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
       with:
-        username: ${{ env.DOCKER_USERNAME }}
-        password: ${{ env.DOCKER_PASSWORD }}
-
-    - name: Build container image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        push: true
-        tags: rancher/hardened-etcd:${{ github.event.release.tag_name }}
-        file: Dockerfile
-        platforms: linux/amd64, linux/arm64
-        build-args: |
-          TAG=${{ env.TAG }}
+        image: hardened-etcd
+        tag: ${{ github.event.release.tag_name }}
+        public-repo: rancher
+        public-username: ${{ env.DOCKER_USERNAME }}
+        public-password: ${{ env.DOCKER_PASSWORD }}
+        push-to-prime: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 ARG GO_IMAGE=rancher/hardened-build-base:v1.22.7b1
-ARG ARCH="amd64"
 
 # Image that provides cross compilation tooling.
 FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.3.0 as xx
@@ -18,6 +17,7 @@ RUN set -x && \
 
 FROM base-builder as etcd-builder
 # setup the build
+ARG TARGETARCH
 ARG PKG=go.etcd.io/etcd
 ARG SRC=github.com/k3s-io/etcd
 ARG TAG="v3.5.13-k3s1"
@@ -44,7 +44,7 @@ RUN xx-verify --static bin/*
 RUN go-assert-static.sh bin/*
 ARG ETCD_UNSUPPORTED_ARCH
 ENV ETCD_UNSUPPORTED_ARCH=$ETCD_UNSUPPORTED_ARCH
-RUN if [ "${ARCH}" = "amd64" ]; then \
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
 	    go-assert-boring.sh bin/*; \
     fi
 RUN install bin/* /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ image-build:
 push-image:
 	docker buildx build \
 		$(BUILD_OPTS) \
+		$(IID_FILE_FLAG) \
 		--sbom=true \
 		--attest type=provenance,mode=max \
 		--push \

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 SEVERITIES = HIGH,CRITICAL
 
 UNAME_M = $(shell uname -m)
-ARCH=
-ifeq ($(UNAME_M), x86_64)
-	ARCH=amd64
-else ifeq ($(UNAME_M), aarch64)
-	ARCH=arm64
-else 
-	ARCH=$(UNAME_M)
+ifndef TARGET_PLATFORMS
+	ifeq ($(UNAME_M), x86_64)
+		TARGET_PLATFORMS:=linux/amd64
+	else ifeq ($(UNAME_M), aarch64)
+		TARGET_PLATFORMS:=linux/arm64
+	else 
+		TARGET_PLATFORMS:=linux/$(UNAME_M)
+	endif
 endif
 
 BUILD_META=-build$(shell date +%Y%m%d)
-ORG ?= rancher
 PKG ?= go.etcd.io/etcd
 SRC ?= github.com/k3s-io/etcd
 TAG ?= ${GITHUB_ACTION_TAG}
@@ -24,35 +24,44 @@ ifeq (,$(filter %$(BUILD_META),$(TAG)))
 $(error TAG needs to end with build metadata: $(BUILD_META))
 endif
 
+REPO ?= rancher
+IMAGE = $(REPO)/hardened-etcd:$(TAG)
+BUILD_OPTS = \
+	--platform=$(TARGET_PLATFORMS) \
+	--build-arg PKG=$(PKG) \
+	--build-arg SRC=$(SRC) \
+	--build-arg TAG=$(TAG:$(BUILD_META)=) \
+	--build-arg ETCD_UNSUPPORTED_ARCH=$(ETCD_UNSUPPORTED_ARCH) \
+	--tag "$(IMAGE)"
+
 .PHONY: image-build
 image-build:
 	docker buildx build \
+		$(BUILD_OPTS) \
 		--pull \
-		--platform=$(ARCH) \
-		--build-arg PKG=$(PKG) \
-		--build-arg SRC=$(SRC) \
-		--build-arg TAG=$(TAG:$(BUILD_META)=) \
-		--build-arg ARCH=$(ARCH) \
-		--build-arg ETCD_UNSUPPORTED_ARCH=$(ETCD_UNSUPPORTED_ARCH) \
-		--tag $(ORG)/hardened-etcd:$(TAG) \
-		--tag $(ORG)/hardened-etcd:$(TAG)-$(ARCH) \
 		--load \
 	.
 
-.PHONY: image-push
-image-push:
-	docker push $(ORG)/hardened-etcd:$(TAG)-$(ARCH)
+.PHONY: push-image
+push-image:
+	docker buildx build \
+		$(BUILD_OPTS) \
+		--sbom=true \
+		--attest type=provenance,mode=max \
+		--push \
+		.
 
 .PHONY: image-scan
 image-scan:
-	trivy image --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-etcd:$(TAG)
+	trivy image --severity $(SEVERITIES) --no-progress --ignore-unfixed $(IMAGE)
 
 PHONY: log
 log:
-	@echo "ARCH=$(ARCH)"
 	@echo "TAG=$(TAG:$(BUILD_META)=)"
-	@echo "ORG=$(ORG)"
+	@echo "REPO=$(REPO)"
+	@echo "IMAGE=$(IMAGE)"
 	@echo "PKG=$(PKG)"
 	@echo "SRC=$(SRC)"
 	@echo "BUILD_META=$(BUILD_META)"
 	@echo "UNAME_M=$(UNAME_M)"
+	@echo "TARGET_PLATFORMS=$(TARGET_PLATFORMS)"


### PR DESCRIPTION
- use rancher/ecm-distro-tools/actions/publish-image to build and push images
- adds make target push-image
- adds sbom to docker build arguments
- signs images that are pushed to the prime registry