### PR TITLE
Bump golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_IMAGE=rancher/hardened-build-base:v1.22.7b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.23.6b1
 
 # Image that provides cross compilation tooling.
 FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.5.0 as xx


### PR DESCRIPTION
etcd v3.5.19 requires golang 1.23

```
#24 [linux/amd64 etcd-builder  4/11] RUN git checkout tags/v3.5.19-k3s1 -b v3.5.19-k3s1
#24 0.396 Switched to a new branch 'v3.5.19-k3s1'
#24 DONE 0.4s

#25 [linux/amd64 etcd-builder  5/11] RUN go mod vendor
#25 0.071 go: go.mod requires go >= 1.23.0 (running go 1.22.7; GOTOOLCHAIN=local)
#25 ERROR: process "/bin/sh -c go mod vendor" did not complete successfully: exit code: 1
```