### PR TITLE
chore(ci): bump aquasecurity/trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           TAG=${{ env.TAG }}
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.34.2
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         image-ref: rancher/hardened-etcd:${{ env.TAG }}-amd64
         ignore-unfixed: true


### PR DESCRIPTION
Updates GitHub Actions workflows to pin aquasecurity/trivy-action to v0.35.0.

CC @pdellamore