### PR TITLE
Bump hardened-build-base to v1.25.12b1 for Go CVE fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_IMAGE=rancher/hardened-build-base:v1.25.11b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.25.12b1
 
 # Image that provides cross compilation tooling.
 FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.6.1 AS xx


### PR DESCRIPTION
Bumps `rancher/hardened-build-base` to pick up the latest Go CVE fix from the freshly cut hardened-build-base release. Patch bump only (stays on the same Go minor line).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>