### PR TITLE
Add go-mod-overrides with google.golang.org/grpc v1.82.1 for GHSA-hrxh-6v49-42gf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}
+COPY go-mod-overrides ./go-mod-overrides
+RUN go-mod-overrides.sh ./go-mod-overrides
 RUN go mod vendor
 RUN go mod download
 # cross-compilation setup

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,0 +1,3 @@
+# google.golang.org/grpc: GHSA-hrxh-6v49-42gf (xDS RBAC auth bypass, HTTP/2 Rapid Reset DoS).
+# Drop once upstream requires google.golang.org/grpc >= v1.82.1.
+-replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1


### PR DESCRIPTION
## What
Adds a go.mod override pinning `google.golang.org/grpc` to `v1.82.1` to remediate GHSA-hrxh-6v49-42gf.

## Why
GHSA-hrxh-6v49-42gf (grpc-go `< 1.82.1`) covers an xDS RBAC authorization bypass (fail-open) and an HTTP/2 Rapid Reset mitigation bypass (DoS). This image was flagged as affected in the 2026-07-22 hardened image scan.

## How
Follows the go-mod-overrides pattern from rancher/image-build-external-snapshotter#16: the tracked `go-mod-overrides` file lists a `-replace` directive applied at build time by `go-mod-overrides.sh` (`go mod edit` + `go mod tidy`, re-vendoring only when a vendor dir exists).

Drop the override once upstream requires `google.golang.org/grpc >= v1.82.1`.
