### PR TITLE
Build etcd/etcdctl from the root module so the grpc override applies (GHSA-hrxh-6v49-42gf)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,17 @@ RUN go mod download
 # cross-compilation setup
 ARG TARGETPLATFORM
 # build and assert statically linked executable(s)
+# For v3.6+ (multi-module) build the binaries from the root module by package path so the
+# go-mod-overrides grpc replace applies; building inside server/ and etcdctl/ would use their
+# own go.mod (grpc v1.79.3) and ship the vulnerable dependency.
 RUN xx-go --wrap && \
     export GO_LDFLAGS="-linkmode=external -X ${PKG}/version.GitSHA=$(git rev-parse --short HEAD)" && \
     if echo ${TAG} | grep -qE '^v3\.4\.'; then \
         go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o bin/etcd . && \
         go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o bin/etcdctl ./etcdctl; \
     else \
-        cd $GOPATH/src/${PKG}/server  && go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o ../bin/etcd . && \
-        cd $GOPATH/src/${PKG}/etcdctl && go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o ../bin/etcdctl .; \
+        go-build-static.sh -mod=mod -gcflags=-trimpath=${GOPATH}/src -o bin/etcd go.etcd.io/etcd/server/v3 && \
+        go-build-static.sh -mod=mod -gcflags=-trimpath=${GOPATH}/src -o bin/etcdctl go.etcd.io/etcd/etcdctl/v3; \
     fi
 
 RUN xx-verify --static bin/*


### PR DESCRIPTION
## Problem

The build20260722 rebuild of `hardened-etcd:v3.6.12-k3s1` (#111 / 442a94f) added a go-mod-override for `google.golang.org/grpc@v1.82.1` to remediate GHSA-hrxh-6v49-42gf, but trivy still flags the vulnerable grpc in the resulting image.

## Root cause

etcd v3.6+ is a multi-module repo. The `etcd` and `etcdctl` binaries are built from the `server/` and `etcdctl/` subdirectories, which are separate Go modules with their own `go.mod` requiring `google.golang.org/grpc v1.79.3` and no replace for grpc.

`go-mod-overrides.sh` runs from the repo root and only edits the root module (`go.etcd.io/etcd/v3`). The `cd server && go build .` / `cd etcdctl && go build .` steps build in those submodules, whose go.mod still pins grpc v1.79.3, so the shipped binaries linked the vulnerable version.

Applying the override inside the submodules is not viable: a `go mod tidy` there trips etcd's own `FORBIDDEN_DEPENDENCY` guard, because grpc's benchmark dependency chain (grpc -> gonum -> ... -> go.etcd.io/etcd@<ancient>) resolves the forbidden legacy module. That guard only exists to be tripped, and `tidy` cannot complete.

## Fix

Build the v3.6+ binaries from the **root** module by package path (`go.etcd.io/etcd/server/v3` and `go.etcd.io/etcd/etcdctl/v3`) with `-mod=mod`. The root module carries the grpc replace and its go.sum is reconciled by `go-mod-overrides.sh`, so the binaries link grpc v1.82.1. The single-module v3.4 path is unchanged.

## Testing

Reproduced the full builder flow locally for `v3.6.12-k3s1` (root override + tidy + vendor + download, then the new build commands):

```
etcd grpc:    google.golang.org/grpc v1.82.1
etcdctl grpc: google.golang.org/grpc v1.82.1
etcd Version: 3.6.12
etcdctl version: 3.6.12
```

`go version -m` on both binaries now shows `google.golang.org/grpc v1.79.3 => v1.82.1` as the linked dependency.

## Follow-up

Once merged and a new `hardened-etcd:v3.6.12-k3s1-build<date>` is published, the etcd tag needs re-bumping to the new build date in rke2 and rke2-charts (the current build20260722 tag still contains the vulnerable binary).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>